### PR TITLE
nbinomLRT shouldn't be called directly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: stageR
 Type: Package
 Title: stageR: stage-wise analysis of high throughput gene expression data in R
-Version: 1.3.26
+Version: 1.3.27
 Author: Koen Van den Berge and Lieven Clement
 Maintainer: Koen Van den Berge <koen.vdberge@gmail.com>
 Description: The stageR package allows automated stage-wise analysis of high-throughput gene expression data. The method is published in Genome Biology at https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1277-0

--- a/vignettes/stageRVignette.Rmd
+++ b/vignettes/stageRVignette.Rmd
@@ -205,7 +205,7 @@ dxd <- DEXSeqDataSet(countData = exprs(esetProstate),
                      groupID = as.character(geneForEachTx))
 dxd <- estimateSizeFactors(dxd)
 dxd <- estimateDispersions(dxd)
-dxd <- nbinomLRT(dxd, reduced=~ sample + exon + patient)
+dxd <- testForDEU(dxd, reducedModel=~ sample + exon + patient)
 dxr <- DEXSeqResults(dxd)
 qvalDxr <- perGeneQValue(dxr)
 ```


### PR DESCRIPTION
There is a difference between `nbinomLRT` and `testForDEU`, which is that the latter version checks to see if the model matrix is full rank, and if not, it removes specific columns to make it full rank (this is good). 

These model matrices produced by `nbinomLRT` using DEXSeq will not be full rank because R's `model.matrix` function adds an extra column for the condition interaction effect with the "other exons". This induces a linear dependence between the sample coefficients and the condition interaction terms (in a simple 3 vs 3 experiment, the linear relationship will be sample 4 + 5 + 6 = exonthis:conditionB + exonothers:conditionB). The code runs, because I didn't have a check for full rank at this later step in DESeq2. There are checks for full rank in DESeq2, but they occur at object construction and at dispersion estimation (both bypassed by DEXSeq), and the DESeq2 code wasn't checking at every step, but it should. I'm adding code to DESeq2 devel branch now which will error out on these model matrices, which it should. 

The fix here is to use `testForDEU`. I also have to fix the rnaseqDTU workflow, where I used the `nbinomLRT` code. Something I haven't fully explored is that using `nbinomLRT` made DEXSeq appear more conservative than it is using the correct code. My first guess to the cause is the degrees of freedom of the chi square being one larger with the extra column.