### PR TITLE
Factors in tx2gene cause issues

### DIFF
--- a/R/constructors.R
+++ b/R/constructors.R
@@ -71,6 +71,8 @@ stageRTx <- function(pScreen, pConfirmation, pScreenAdjusted=FALSE, tx2gene){
     stop("not all transcript names in pConfirmation match with a transcript ID from the tx2gene object.")
   if(any(is.na(match(names(pScreen),tx2gene[,2]))))
     stop("not all gene names in pScreen match with a gene ID from the tx2gene object.")
+  if(class(tx2gene[,1]) == "factor" | class(tx2gene[,2]) == "factor")
+    stop("columns of tx2gene should be character, not factor")
   stageR <- new("stageRTx")
   stageR@pScreen <- pScreen
   stageR@pConfirmation <- pConfirmation


### PR DESCRIPTION
I don't have a small example on hand, but I noticed that when tx2gene has columns that are factors, the screening adjusted p-values are not in the correct order in the output. Easiest solution is to coerce to character before before providing to stageRTx. Let me know if you need an example, I can follow up.